### PR TITLE
Fix indentation in default config

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -459,8 +459,8 @@ widgets:
           on_right: "exec cmd.exe /c start ms-settings:network"
 
   traffic:
-  type: "yasb.traffic.TrafficWidget"
-  options:
+    type: "yasb.traffic.TrafficWidget"
+    options:
       label: "\ueb01 \ueab4 {download_speed} | \ueab7 {upload_speed}"
       label_alt: "\ueb01 \ueab4 {upload_speed} | \ueab7 {download_speed}"
       update_interval: 1000 # Update interval should be a multiple of 1000


### PR DESCRIPTION
Yes, it is a low-quality PR. But it really is a confusing error for someone trying out YASB for the first time.

<!--- Provide a general summary of your changes in the Title above -->

## Description
To reproduce, just copy the existing `config.yaml` into your own config, and the following error will occur:
```bash
Yasb - Yet Another Status Bar
The config file 'C:\Users\<User>\.yasb\config.yaml' contains validation errors. Please fix:
widgets:
- traffic:
  - null value not allowed

User config file could not be loaded. Exiting Application.
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
