### PR TITLE
fix: Fix Monitor Specific Active Window Widget

### DIFF
--- a/src/core/widgets/yasb/active_window.py
+++ b/src/core/widgets/yasb/active_window.py
@@ -96,8 +96,11 @@ class ActiveWindowWidget(BaseWidget):
             return
 
         monitor_xpos = win_info['monitor_info'].get('rect', None).get('x', None)
+        monitor_ypos = win_info['monitor_info'].get('rect', None).get('y', None)
 
-        if self._monitor_exclusive and self.screen().geometry().x() != monitor_xpos:
+        if (self._monitor_exclusive and 
+           (self.screen().geometry().x() != monitor_xpos or
+            self.screen().geometry().y() != monitor_ypos)):
             self._window_title_text.hide()
         else:
             self._update_window_title(hwnd, win_info, event)

--- a/src/core/widgets/yasb/active_window.py
+++ b/src/core/widgets/yasb/active_window.py
@@ -95,9 +95,9 @@ class ActiveWindowWidget(BaseWidget):
                 win_info['class_name'] in IGNORED_YASB_CLASSES):
             return
 
-        monitor_name = win_info['monitor_info'].get('device', None)
+        monitor_xpos = win_info['monitor_info'].get('rect', None).get('x', None)
 
-        if self._monitor_exclusive and self.screen().name() != monitor_name:
+        if self._monitor_exclusive and self.screen().geometry().x() != monitor_xpos:
             self._window_title_text.hide()
         else:
             self._update_window_title(hwnd, win_info, event)


### PR DESCRIPTION
# Pull Request #86

## Description
The Active Window widget does not appropriately determine whether or not the text should be hidden if the monitor exclusive option is set to true. I set up an alternate method to identify what monitor a widget is on in the logic to determine whether or not the window title text should be hidden.

PyQT6 QWidgets don't have access to the win32 hwnd info for a monitor, they just return //Display 1 or //Display 2. We can identify what monitor a widget is on by using the screens x-offset and the hwnd monitor_info's rectangle x value (0 for the leftmost monitor and whatever the horizontal resolution of the first monitor is for the second, and so on). Just in case somebody has vertically stacked mutltiple monitors, there is also a check for the y value.

## Related Issue
Fixes Issue #86 

## Testing
I made the change yesterday in my personal config and everything is working fine.