### PR TITLE
Fix indentation for traffic widget in default config

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -459,8 +459,8 @@ widgets:
           on_right: "exec cmd.exe /c start ms-settings:network"
 
   traffic:
-  type: "yasb.traffic.TrafficWidget"
-  options:
+    type: "yasb.traffic.TrafficWidget"
+    options:
       label: "\ueb01 \ueab4 {download_speed} | \ueab7 {upload_speed}"
       label_alt: "\ueb01 \ueab4 {upload_speed} | \ueab7 {download_speed}"
       update_interval: 1000 # Update interval should be a multiple of 1000


### PR DESCRIPTION
# Pull Request #137 

## Description

The `config.yaml` located in the `src/` directory is not valid due to indentation not being correct. This causes the program to crash using the default config, which is obviously not correct.

## Related Issue
#137 


## Testing
 - Apply indentation fix to default config
 - Use default config by moving it to `~/.yasb`
 - See that yasb now functions
